### PR TITLE
Add requests latency metric

### DIFF
--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -1,5 +1,9 @@
 package core
 
+import (
+	"time"
+)
+
 type Adapters struct {
 	Fetcher Fetcher
 	Paths   Paths
@@ -20,6 +24,7 @@ type Logger interface {
 	OriginalDownloaded(source string, destination string)
 	OriginalDownloadFailed(source string)
 	OriginalDownloadSkipped(source string)
+	RequestLatency(handler string, duration time.Duration)
 }
 
 // Processor

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -24,7 +24,7 @@ type Logger interface {
 	OriginalDownloaded(source string, destination string)
 	OriginalDownloadFailed(source string)
 	OriginalDownloadSkipped(source string)
-	RequestLatency(handler string, duration time.Duration)
+	RequestLatency(handler string, since time.Time)
 }
 
 // Processor

--- a/logger/logfile/logfile.go
+++ b/logger/logfile/logfile.go
@@ -47,5 +47,5 @@ func (l *Logger) OriginalDownloadFailed(source string) {
 func (l *Logger) OriginalDownloadSkipped(source string) {
 }
 
-func (l *Logger) RequestLatency(handler string, duration time.Duration) {
+func (l *Logger) RequestLatency(handler string, since time.Time) {
 }

--- a/logger/logfile/logfile.go
+++ b/logger/logfile/logfile.go
@@ -1,6 +1,8 @@
 package logfile
 
 import (
+	"time"
+
 	"github.com/golang/glog"
 	"github.com/image-server/image-server/core"
 	"github.com/image-server/image-server/logger"
@@ -43,4 +45,7 @@ func (l *Logger) OriginalDownloadFailed(source string) {
 }
 
 func (l *Logger) OriginalDownloadSkipped(source string) {
+}
+
+func (l *Logger) RequestLatency(handler string, duration time.Duration) {
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,6 +1,10 @@
 package logger
 
-import "github.com/image-server/image-server/core"
+import (
+	"time"
+
+	"github.com/image-server/image-server/core"
+)
 
 var Loggers []core.Logger
 
@@ -65,5 +69,11 @@ func OriginalDownloadFailed(source string) {
 func OriginalDownloadSkipped(source string) {
 	for _, logger := range Loggers {
 		go logger.OriginalDownloadSkipped(source)
+	}
+}
+
+func RequestLatency(handler string, duration time.Duration) {
+	for _, logger := range Loggers {
+		go logger.RequestLatency(handler, duration)
 	}
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -72,8 +72,8 @@ func OriginalDownloadSkipped(source string) {
 	}
 }
 
-func RequestLatency(handler string, duration time.Duration) {
+func RequestLatency(handler string, since time.Time) {
 	for _, logger := range Loggers {
-		go logger.RequestLatency(handler, duration)
+		go logger.RequestLatency(handler, since)
 	}
 }

--- a/logger/prometheus/metrics.go
+++ b/logger/prometheus/metrics.go
@@ -19,6 +19,7 @@ type Metrics struct {
 	originalDownloadedMetric        prometheus.Counter
 	originalDownloadFailedMetric    prometheus.Counter
 	originalDownloadSkippedMetric   prometheus.Counter
+	requestLatency                  *prometheus.HistogramVec
 }
 
 // CreateAndRegisterMetrics creates a struct of Metrics
@@ -118,6 +119,15 @@ func CreateAndRegisterMetrics() *Metrics {
 		},
 	)
 	prometheus.MustRegister(metrics.originalDownloadSkippedMetric)
+
+	metrics.requestLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "image_server_request_latency_seconds",
+			Help: "Latency for requests made towards the api",
+		},
+		[]string{"handler"},
+	)
+	prometheus.MustRegister(metrics.requestLatency)
 
 	return &metrics
 }

--- a/logger/prometheus/prometheus.go
+++ b/logger/prometheus/prometheus.go
@@ -2,6 +2,7 @@ package prometheus
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/image-server/image-server/core"
 	"github.com/image-server/image-server/logger"
@@ -69,4 +70,9 @@ func (l *Logger) OriginalDownloadFailed(source string) {
 // OriginalDownloadSkipped posts an original download skipped metric
 func (l *Logger) OriginalDownloadSkipped(source string) {
 	l.metrics.originalDownloadSkippedMetric.Inc()
+}
+
+// RequestLatency adds the latency for a request
+func (l *Logger) RequestLatency(handler string, duration time.Duration) {
+	l.metrics.requestLatency.WithLabelValues(handler).Observe(duration.Seconds())
 }

--- a/logger/prometheus/prometheus.go
+++ b/logger/prometheus/prometheus.go
@@ -73,6 +73,6 @@ func (l *Logger) OriginalDownloadSkipped(source string) {
 }
 
 // RequestLatency adds the latency for a request
-func (l *Logger) RequestLatency(handler string, duration time.Duration) {
-	l.metrics.requestLatency.WithLabelValues(handler).Observe(duration.Seconds())
+func (l *Logger) RequestLatency(handler string, since time.Time) {
+	l.metrics.requestLatency.WithLabelValues(handler).Observe(time.Since(since).Seconds())
 }

--- a/logger/statsd/statsd.go
+++ b/logger/statsd/statsd.go
@@ -67,6 +67,10 @@ func (l *Logger) OriginalDownloadSkipped(source string) {
 	l.track("fetch.original_download_skipped")
 }
 
+func (l *Logger) RequestLatency(handler string, duration time.Duration) {
+	l.statsd.Timing(fmt.Sprintf("%s.request_latency", handler), int64(duration.Seconds()))
+}
+
 func (l *Logger) track(name string) {
 	metric := fmt.Sprintf("%s_count", name)
 	l.statsd.Incr(metric, 1)

--- a/logger/statsd/statsd.go
+++ b/logger/statsd/statsd.go
@@ -67,8 +67,8 @@ func (l *Logger) OriginalDownloadSkipped(source string) {
 	l.track("fetch.original_download_skipped")
 }
 
-func (l *Logger) RequestLatency(handler string, duration time.Duration) {
-	l.statsd.Timing(fmt.Sprintf("%s.request_latency", handler), int64(duration.Seconds()))
+func (l *Logger) RequestLatency(handler string, since time.Time) {
+	l.statsd.Timing(fmt.Sprintf("%s.request_latency", handler), int64(time.Since(since).Seconds()))
 }
 
 func (l *Logger) track(name string) {

--- a/server/batch_handler.go
+++ b/server/batch_handler.go
@@ -4,15 +4,19 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/image-server/image-server/core"
 	mantajob "github.com/image-server/image-server/job/manta"
+	"github.com/image-server/image-server/logger"
 	"github.com/image-server/image-server/uploader/manta/client"
 	"github.com/unrolled/render"
 )
 
 func CreateBatchHandler(w http.ResponseWriter, req *http.Request, sc *core.ServerConfiguration) {
+	defer logger.RequestLatency("create_batch", time.Now())
+
 	vars := mux.Vars(req)
 	namespace := vars["namespace"]
 
@@ -36,6 +40,8 @@ func CreateBatchHandler(w http.ResponseWriter, req *http.Request, sc *core.Serve
 }
 
 func BatchHandler(w http.ResponseWriter, req *http.Request, sc *core.ServerConfiguration) {
+	defer logger.RequestLatency("batch", time.Now())
+
 	vars := mux.Vars(req)
 	uuid := vars["uuid"]
 

--- a/server/new_file_handler.go
+++ b/server/new_file_handler.go
@@ -2,10 +2,12 @@ package server
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/gorilla/mux"
 	"github.com/image-server/image-server/core"
+	"github.com/image-server/image-server/logger"
 	"github.com/image-server/image-server/request"
 	"github.com/image-server/image-server/uploader"
 	"github.com/unrolled/render"
@@ -16,6 +18,8 @@ type NewFileResponse struct {
 
 // NewFileHandler handles posting new files
 func NewFileHandler(w http.ResponseWriter, req *http.Request, sc *core.ServerConfiguration) {
+	defer logger.RequestLatency("new_file", time.Now())
+
 	qs := req.URL.Query()
 	vars := mux.Vars(req)
 	sourceURL := qs.Get("source")

--- a/server/new_image_handler.go
+++ b/server/new_image_handler.go
@@ -3,6 +3,7 @@ package server
 import (
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/gorilla/mux"
@@ -16,6 +17,7 @@ import (
 
 // NewImageHandler handles posting new images
 func NewImageHandler(w http.ResponseWriter, req *http.Request, sc *core.ServerConfiguration) {
+	defer logger.RequestLatency("new_image", time.Now())
 	go logger.ImagePosted()
 
 	qs := req.URL.Query()

--- a/server/resize_handler.go
+++ b/server/resize_handler.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/image-server/image-server/core"
+	"github.com/image-server/image-server/logger"
 	"github.com/image-server/image-server/parser"
 	"github.com/image-server/image-server/request"
 	"github.com/image-server/image-server/uploader"
@@ -17,6 +19,8 @@ import (
 // When an image is requested more than once, only one will do the processing,
 // and both requests will return the same output
 func ResizeHandler(w http.ResponseWriter, req *http.Request, sc *core.ServerConfiguration) {
+	defer logger.RequestLatency("resize_image", time.Now())
+
 	vars := mux.Vars(req)
 	filename := vars["filename"]
 

--- a/server/resize_many_handler.go
+++ b/server/resize_many_handler.go
@@ -3,9 +3,11 @@ package server
 import (
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/image-server/image-server/core"
+	"github.com/image-server/image-server/logger"
 	"github.com/image-server/image-server/uploader"
 
 	"github.com/image-server/image-server/request"
@@ -16,6 +18,8 @@ import (
 // A listing will be requested to the uploader to determine what images are missing, and only
 // Images not already processed will be generated and uploaded
 func ResizeManyHandler(w http.ResponseWriter, req *http.Request, sc *core.ServerConfiguration) {
+	logger.RequestLatency("resize_many", time.Now())
+
 	qs := req.URL.Query()
 	vars := mux.Vars(req)
 

--- a/server/resize_many_handler.go
+++ b/server/resize_many_handler.go
@@ -18,7 +18,7 @@ import (
 // A listing will be requested to the uploader to determine what images are missing, and only
 // Images not already processed will be generated and uploaded
 func ResizeManyHandler(w http.ResponseWriter, req *http.Request, sc *core.ServerConfiguration) {
-	logger.RequestLatency("resize_many", time.Now())
+	defer logger.RequestLatency("resize_many", time.Now())
 
 	qs := req.URL.Query()
 	vars := mux.Vars(req)

--- a/server/server.go
+++ b/server/server.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/image-server/image-server/core"
-	"github.com/image-server/image-server/logger"
 	"github.com/tylerb/graceful"
 	"github.com/urfave/negroni"
 )
@@ -27,39 +26,27 @@ func NewRouter(sc *core.ServerConfiguration) *mux.Router {
 	router := mux.NewRouter()
 
 	router.HandleFunc("/{namespace:[a-z0-9_]+}", func(wr http.ResponseWriter, req *http.Request) {
-		start := time.Now()
 		NewImageHandler(wr, req, sc)
-		go logger.RequestLatency("new_image", time.Since(start))
 	}).Methods("POST").Name("newImage")
 
 	router.HandleFunc("/{namespace:[a-z0-9_]+}/{id1:[a-f0-9]{3}}/{id2:[a-f0-9]{3}}/{id3:[a-f0-9]{3}}/{id4:[a-f0-9]{23}}/process", func(wr http.ResponseWriter, req *http.Request) {
-		start := time.Now()
 		ResizeManyHandler(wr, req, sc)
-		go logger.RequestLatency("resize_many", time.Since(start))
 	}).Methods("POST").Name("resizeMany")
 
 	router.HandleFunc("/{namespace:[a-z0-9_]+}/{id1:[a-f0-9]{3}}/{id2:[a-f0-9]{3}}/{id3:[a-f0-9]{3}}/{id4:[a-f0-9]{23}}/{filename}", func(wr http.ResponseWriter, req *http.Request) {
-		start := time.Now()
 		ResizeHandler(wr, req, sc)
-		go logger.RequestLatency("resize_image", time.Since(start))
 	}).Methods("GET").Name("resizeImage")
 
 	router.HandleFunc("/{namespace:[a-z0-9_]+}/{id1:[a-f0-9]{3}}/{id2:[a-f0-9]{3}}/{id3:[a-f0-9]{3}}/{id4:[a-f0-9]{23}}/{filename}", func(wr http.ResponseWriter, req *http.Request) {
-		start := time.Now()
 		NewFileHandler(wr, req, sc)
-		go logger.RequestLatency("new_file", time.Since(start))
 	}).Methods("POST").Name("newFile")
 
 	router.HandleFunc("/{namespace:[a-z0-9_]+}/batch", func(wr http.ResponseWriter, req *http.Request) {
-		start := time.Now()
 		CreateBatchHandler(wr, req, sc)
-		go logger.RequestLatency("create_batch", time.Since(start))
 	}).Methods("POST").Name("createBatch")
 
 	router.HandleFunc("/{namespace:[a-z0-9_]+}/batch/{uuid:[a-f0-9-]{36}}", func(wr http.ResponseWriter, req *http.Request) {
-		start := time.Now()
 		BatchHandler(wr, req, sc)
-		go logger.RequestLatency("batch", time.Since(start))
 	}).Methods("GET").Name("batch")
 
 	admin := &AdminHandler{}

--- a/server/server.go
+++ b/server/server.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/image-server/image-server/core"
+	"github.com/image-server/image-server/logger"
 	"github.com/tylerb/graceful"
 	"github.com/urfave/negroni"
 )
@@ -26,27 +27,39 @@ func NewRouter(sc *core.ServerConfiguration) *mux.Router {
 	router := mux.NewRouter()
 
 	router.HandleFunc("/{namespace:[a-z0-9_]+}", func(wr http.ResponseWriter, req *http.Request) {
+		start := time.Now()
 		NewImageHandler(wr, req, sc)
+		go logger.RequestLatency("new_image", time.Since(start))
 	}).Methods("POST").Name("newImage")
 
 	router.HandleFunc("/{namespace:[a-z0-9_]+}/{id1:[a-f0-9]{3}}/{id2:[a-f0-9]{3}}/{id3:[a-f0-9]{3}}/{id4:[a-f0-9]{23}}/process", func(wr http.ResponseWriter, req *http.Request) {
+		start := time.Now()
 		ResizeManyHandler(wr, req, sc)
+		go logger.RequestLatency("resize_many", time.Since(start))
 	}).Methods("POST").Name("resizeMany")
 
 	router.HandleFunc("/{namespace:[a-z0-9_]+}/{id1:[a-f0-9]{3}}/{id2:[a-f0-9]{3}}/{id3:[a-f0-9]{3}}/{id4:[a-f0-9]{23}}/{filename}", func(wr http.ResponseWriter, req *http.Request) {
+		start := time.Now()
 		ResizeHandler(wr, req, sc)
+		go logger.RequestLatency("resize_image", time.Since(start))
 	}).Methods("GET").Name("resizeImage")
 
 	router.HandleFunc("/{namespace:[a-z0-9_]+}/{id1:[a-f0-9]{3}}/{id2:[a-f0-9]{3}}/{id3:[a-f0-9]{3}}/{id4:[a-f0-9]{23}}/{filename}", func(wr http.ResponseWriter, req *http.Request) {
+		start := time.Now()
 		NewFileHandler(wr, req, sc)
+		go logger.RequestLatency("new_file", time.Since(start))
 	}).Methods("POST").Name("newFile")
 
 	router.HandleFunc("/{namespace:[a-z0-9_]+}/batch", func(wr http.ResponseWriter, req *http.Request) {
+		start := time.Now()
 		CreateBatchHandler(wr, req, sc)
+		go logger.RequestLatency("create_batch", time.Since(start))
 	}).Methods("POST").Name("createBatch")
 
 	router.HandleFunc("/{namespace:[a-z0-9_]+}/batch/{uuid:[a-f0-9-]{36}}", func(wr http.ResponseWriter, req *http.Request) {
+		start := time.Now()
 		BatchHandler(wr, req, sc)
+		go logger.RequestLatency("batch", time.Since(start))
 	}).Methods("GET").Name("batch")
 
 	admin := &AdminHandler{}


### PR DESCRIPTION
This PR adds a new metric to measure the requests latency. This metric is only used for the main server, not the server one.

For *prometheus*: adds the metric `image_server_request_latency_seconds` histogram, with the handler as label.
For *statsd*: adds the `<handler>.request_latency` timing metric.