### PR TITLE
RETURN-9183 Issue downloading images when not having a user-agent hea…

### DIFF
--- a/core/version.go
+++ b/core/version.go
@@ -1,7 +1,7 @@
 package core
 
 // VERSION number of current image server
-const VERSION = "1.19.0"
+const VERSION = "1.19.1"
 
 // GitHash is the git hash and is set at build time as a ldflags
 var GitHash = "GitHash is not defined"

--- a/fetcher/http/client.go
+++ b/fetcher/http/client.go
@@ -44,13 +44,15 @@ func (c *Client) Get(urlStr string) (resp *http.Response, err error) {
 	p = slashReg.ReplaceAllString(p, "/")
 	u.Opaque = p
 
+	header := make(http.Header)
+	header.Add("user-agent", "image-server")
 	req := &http.Request{
 		Method:     "GET",
 		URL:        u,
 		Proto:      "HTTP/1.1",
 		ProtoMajor: 1,
 		ProtoMinor: 1,
-		Header:     make(http.Header),
+		Header:     header,
 		Host:       u.Host,
 	}
 


### PR DESCRIPTION
Added user-agent header with a value neutral "image-server", this speeds up the downloads from some servers from 10 seconds to less than 2 seconds.

