### PR TITLE
Add user agent to headers on http client

### DIFF
--- a/core/version.go
+++ b/core/version.go
@@ -1,7 +1,7 @@
 package core
 
 // VERSION number of current image server
-const VERSION = "1.19.0"
+const VERSION = "1.19.1"
 
 // GitHash is the git hash and is set at build time as a ldflags
 var GitHash = "GitHash is not defined"

--- a/fetcher/http/client.go
+++ b/fetcher/http/client.go
@@ -44,13 +44,15 @@ func (c *Client) Get(urlStr string) (resp *http.Response, err error) {
 	p = slashReg.ReplaceAllString(p, "/")
 	u.Opaque = p
 
+	header := make(http.Header)
+	header.Add("user-agent", "image-server")
 	req := &http.Request{
 		Method:     "GET",
 		URL:        u,
 		Proto:      "HTTP/1.1",
 		ProtoMajor: 1,
 		ProtoMinor: 1,
-		Header:     make(http.Header),
+		Header:     header,
 		Host:       u.Host,
 	}
 


### PR DESCRIPTION
Added a default header on http client to improve performance when requesting some servers that seem to be delaying requests when the user-agent is not defined.