### PR TITLE
Add webhook support for image upload and processing events

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A high-performance image processing server written in Go. Supports on-demand ima
 - **Signed URLs** - Secure uploads with HMAC-SHA256 signed URLs (similar to AWS S3 pre-signed URLs)
 - **Batch processing** - Process multiple image sizes in a single request
 - **Prometheus metrics** - Built-in metrics endpoint for monitoring
+- **Webhooks** - Notify external systems when images are uploaded or processed
 - **Docker support** - Ready-to-use Docker image
 
 ## Quick Start
@@ -197,6 +198,120 @@ Sign a path prefix to allow uploads to any path under it:
 ./image-server sign-url --secret "..." --path /products/abc/def/ghi/jkl --ttl 15m
 # Allows only that exact path
 ```
+
+## Webhooks
+
+Send HTTP notifications to external systems when images are uploaded or processed. Useful for triggering downstream workflows like OCR, ML pipelines, or cache invalidation.
+
+### Setup
+
+```bash
+./image-server server \
+  --webhook-url "https://api.example.com/webhooks/images" \
+  --webhook-secret "$(./image-server generate-secret)" \
+  --webhook-timeout 10 \
+  --webhook-events "uploaded,batch_complete"
+```
+
+### Events
+
+| Event | Trigger | Use Case |
+|-------|---------|----------|
+| `uploaded` | Original image uploaded to storage | Start processing pipeline |
+| `processed` | Each image variant processed | Cache warming |
+| `failed` | Processing error | Alerting |
+| `batch_complete` | All variants done (or already existed) | Trigger downstream workflow |
+
+By default, all events are sent. Use `--webhook-events` to filter.
+
+### Payload Format
+
+```json
+{
+  "event": "image.uploaded",
+  "timestamp": "2025-12-09T15:30:00Z",
+  "data": {
+    "namespace": "products",
+    "hash": "6e0072682e66287b662827da75b244a3",
+    "width": 1920,
+    "height": 1080,
+    "content_type": "image/jpeg",
+    "remote_url": "https://cdn.example.com/products/6e0/072/.../original"
+  }
+}
+```
+
+For `image.processed`:
+```json
+{
+  "event": "image.processed",
+  "timestamp": "2025-12-09T15:30:01Z",
+  "data": {
+    "namespace": "products",
+    "hash": "6e0072682e66287b662827da75b244a3",
+    "filename": "x300.webp",
+    "format": "webp",
+    "width": 300,
+    "height": 169,
+    "quality": 75,
+    "remote_url": "https://cdn.example.com/products/6e0/072/.../x300.webp"
+  }
+}
+```
+
+### Security
+
+Webhooks are signed with HMAC-SHA256. Verify the signature in your handler:
+
+**Headers:**
+```
+X-Webhook-Signature: sha256=<hex-encoded-hmac>
+X-Webhook-Timestamp: 1702135800
+```
+
+**Verification (Python):**
+```python
+import hmac
+import hashlib
+
+def verify_webhook(secret: str, timestamp: str, body: bytes, signature: str) -> bool:
+    expected = "sha256=" + hmac.new(
+        secret.encode(),
+        f"{timestamp}.{body.decode()}".encode(),
+        hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(expected, signature)
+
+# In your handler:
+if not verify_webhook(SECRET, request.headers["X-Webhook-Timestamp"],
+                      request.body, request.headers["X-Webhook-Signature"]):
+    return 401
+```
+
+**Verification (Go):**
+```go
+func verifyWebhook(secret, timestamp string, body []byte, signature string) bool {
+    h := hmac.New(sha256.New, []byte(secret))
+    h.Write([]byte(fmt.Sprintf("%s.%s", timestamp, string(body))))
+    expected := "sha256=" + hex.EncodeToString(h.Sum(nil))
+    return hmac.Equal([]byte(expected), []byte(signature))
+}
+```
+
+### Configuration
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--webhook-url` | Endpoint URL (enables webhooks) | - |
+| `--webhook-secret` | HMAC signing secret | - |
+| `--webhook-timeout` | HTTP timeout in seconds | `10` |
+| `--webhook-events` | Events to send (comma-separated) | all |
+
+### Reliability
+
+- Webhooks are sent asynchronously (non-blocking)
+- Failed deliveries retry up to 3 times with exponential backoff (1s, 4s)
+- Webhook failures don't affect image processing
 
 ## Cloud Storage (S3)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/image-server/image-server/fetcher/http"
 	"github.com/image-server/image-server/logger/prometheus"
 	"github.com/image-server/image-server/logger/statsd"
+	"github.com/image-server/image-server/logger/webhook"
 	"github.com/image-server/image-server/paths"
 	"github.com/image-server/image-server/uploader"
 	"github.com/spf13/cobra"
@@ -59,6 +60,12 @@ type configT struct {
 	requireSignatureForRead bool
 	signingSecretsFile      string
 	signatureMaxTTL         int
+
+	// Webhooks
+	webhookURL     string
+	webhookSecret  string
+	webhookTimeout int
+	webhookEvents  string
 }
 
 var config configT
@@ -91,6 +98,17 @@ func serverConfiguration() (*core.ServerConfiguration, error) {
 	}
 	sc.Adapters = adapters
 	sc.CleanUpTicker = time.NewTicker(2 * time.Minute)
+
+	// Enable webhooks if configured
+	if config.webhookURL != "" {
+		webhookCfg := &webhook.Config{
+			URL:     config.webhookURL,
+			Secret:  config.webhookSecret,
+			Timeout: time.Duration(config.webhookTimeout) * time.Second,
+			Events:  parseWebhookEvents(config.webhookEvents),
+		}
+		webhook.Enable(webhookCfg, adapters.Paths)
+	}
 
 	return sc, nil
 }
@@ -192,4 +210,28 @@ func initializeUploader(sc *core.ServerConfiguration) {
 		log.Println("EXITING: Unable to initialize uploader: ", err)
 		os.Exit(2)
 	}
+}
+
+// parseWebhookEvents parses a comma-separated list of webhook events
+func parseWebhookEvents(events string) map[webhook.EventType]bool {
+	if events == "" {
+		return nil // nil means all events
+	}
+
+	result := make(map[webhook.EventType]bool)
+	for _, e := range strings.Split(events, ",") {
+		switch strings.TrimSpace(e) {
+		case "uploaded":
+			result[webhook.EventImageUploaded] = true
+		case "processed":
+			result[webhook.EventImageProcessed] = true
+		case "failed":
+			result[webhook.EventImageProcessingFailed] = true
+		case "batch_complete":
+			result[webhook.EventBatchComplete] = true
+		default:
+			log.Printf("Warning: unknown webhook event type: %s", e)
+		}
+	}
+	return result
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -91,6 +91,12 @@ func init() {
 	serverCmd.Flags().BoolVar(&config.requireSignatureForRead, "require-signature-for-reads", false, "Also require signed URLs for GET requests")
 	serverCmd.Flags().StringVar(&config.signingSecretsFile, "signing-secrets-file", "", "Path to file containing signing secrets (one per line)")
 	serverCmd.Flags().IntVar(&config.signatureMaxTTL, "signature-max-ttl", 60, "Maximum allowed signature TTL in minutes")
+
+	// Webhooks
+	serverCmd.Flags().StringVar(&config.webhookURL, "webhook-url", "", "Webhook endpoint URL (enables webhooks when set)")
+	serverCmd.Flags().StringVar(&config.webhookSecret, "webhook-secret", "", "HMAC secret for signing webhook payloads")
+	serverCmd.Flags().IntVar(&config.webhookTimeout, "webhook-timeout", 10, "Webhook HTTP timeout in seconds")
+	serverCmd.Flags().StringVar(&config.webhookEvents, "webhook-events", "", "Comma-separated list of events to send (default: all). Options: uploaded,processed,failed,batch_complete")
 }
 
 func handleShutdownSignals() {

--- a/core/image_properties.go
+++ b/core/image_properties.go
@@ -1,0 +1,9 @@
+package core
+
+// ImageProperties contains metadata about an uploaded image
+type ImageProperties struct {
+	Hash        string `json:"hash"`
+	Height      int    `json:"height"`
+	Width       int    `json:"width"`
+	ContentType string `json:"content_type"`
+}

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -25,6 +25,7 @@ type Logger interface {
 	OriginalDownloadFailed(source string)
 	OriginalDownloadSkipped(source string)
 	RequestLatency(handler string, since time.Time)
+	OriginalUploaded(props *ImageProperties, namespace string)
 }
 
 // Processor

--- a/core/version.go
+++ b/core/version.go
@@ -1,7 +1,7 @@
 package core
 
 // VERSION number of current image server
-const VERSION = "1.20.0"
+const VERSION = "1.21.0"
 
 // GitHash is the git hash and is set at build time as a ldflags
 var GitHash = "GitHash is not defined"

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -77,3 +77,9 @@ func RequestLatency(handler string, since time.Time) {
 		go logger.RequestLatency(handler, since)
 	}
 }
+
+func OriginalUploaded(props *core.ImageProperties, namespace string) {
+	for _, logger := range Loggers {
+		go logger.OriginalUploaded(props, namespace)
+	}
+}

--- a/logger/prometheus/prometheus.go
+++ b/logger/prometheus/prometheus.go
@@ -76,3 +76,9 @@ func (l *Logger) OriginalDownloadSkipped(source string) {
 func (l *Logger) RequestLatency(handler string, since time.Time) {
 	l.metrics.requestLatency.WithLabelValues(handler).Observe(time.Since(since).Seconds())
 }
+
+// OriginalUploaded is called when an original image is uploaded
+func (l *Logger) OriginalUploaded(props *core.ImageProperties, namespace string) {
+	// Prometheus doesn't need to track individual uploads
+	// Could add a counter here if desired
+}

--- a/logger/statsd/statsd.go
+++ b/logger/statsd/statsd.go
@@ -71,6 +71,10 @@ func (l *Logger) RequestLatency(handler string, since time.Time) {
 	l.statsd.Timing(fmt.Sprintf("%s.request_latency", handler), int64(time.Since(since).Seconds()))
 }
 
+func (l *Logger) OriginalUploaded(props *core.ImageProperties, namespace string) {
+	l.track("upload.original")
+}
+
 func (l *Logger) track(name string) {
 	metric := fmt.Sprintf("%s_count", name)
 	l.statsd.Incr(metric, 1)

--- a/logger/webhook/payload.go
+++ b/logger/webhook/payload.go
@@ -1,0 +1,124 @@
+package webhook
+
+import (
+	"time"
+
+	"github.com/image-server/image-server/core"
+)
+
+// EventType represents the type of webhook event
+type EventType string
+
+const (
+	EventImageUploaded        EventType = "image.uploaded"
+	EventImageProcessed       EventType = "image.processed"
+	EventImageProcessingFailed EventType = "image.processing_failed"
+	EventBatchComplete        EventType = "image.batch_complete"
+)
+
+// Payload is the base webhook payload structure
+type Payload struct {
+	Event     EventType   `json:"event"`
+	Timestamp time.Time   `json:"timestamp"`
+	Data      interface{} `json:"data"`
+}
+
+// UploadedData contains data for image.uploaded events
+type UploadedData struct {
+	Namespace   string `json:"namespace"`
+	Hash        string `json:"hash"`
+	Width       int    `json:"width"`
+	Height      int    `json:"height"`
+	ContentType string `json:"content_type"`
+	RemoteURL   string `json:"remote_url"`
+}
+
+// ProcessedData contains data for image.processed events
+type ProcessedData struct {
+	Namespace string `json:"namespace"`
+	Hash      string `json:"hash"`
+	Filename  string `json:"filename"`
+	Format    string `json:"format"`
+	Width     int    `json:"width"`
+	Height    int    `json:"height"`
+	Quality   uint   `json:"quality"`
+	RemoteURL string `json:"remote_url"`
+}
+
+// ProcessingFailedData contains data for image.processing_failed events
+type ProcessingFailedData struct {
+	Namespace string `json:"namespace"`
+	Hash      string `json:"hash"`
+	Filename  string `json:"filename"`
+	Format    string `json:"format"`
+	Error     string `json:"error,omitempty"`
+}
+
+// BatchCompleteData contains data for image.batch_complete events
+type BatchCompleteData struct {
+	Namespace string `json:"namespace"`
+	Hash      string `json:"hash"`
+	SourceURL string `json:"source_url,omitempty"`
+}
+
+// NewUploadedPayload creates a payload for image.uploaded events
+func NewUploadedPayload(props *core.ImageProperties, namespace string, remoteURL string) *Payload {
+	return &Payload{
+		Event:     EventImageUploaded,
+		Timestamp: time.Now().UTC(),
+		Data: UploadedData{
+			Namespace:   namespace,
+			Hash:        props.Hash,
+			Width:       props.Width,
+			Height:      props.Height,
+			ContentType: props.ContentType,
+			RemoteURL:   remoteURL,
+		},
+	}
+}
+
+// NewProcessedPayload creates a payload for image.processed events
+func NewProcessedPayload(ic *core.ImageConfiguration, remoteURL string) *Payload {
+	return &Payload{
+		Event:     EventImageProcessed,
+		Timestamp: time.Now().UTC(),
+		Data: ProcessedData{
+			Namespace: ic.Namespace,
+			Hash:      ic.ID,
+			Filename:  ic.Filename,
+			Format:    ic.Format,
+			Width:     ic.Width,
+			Height:    ic.Height,
+			Quality:   ic.Quality,
+			RemoteURL: remoteURL,
+		},
+	}
+}
+
+// NewProcessingFailedPayload creates a payload for image.processing_failed events
+func NewProcessingFailedPayload(ic *core.ImageConfiguration, errMsg string) *Payload {
+	return &Payload{
+		Event:     EventImageProcessingFailed,
+		Timestamp: time.Now().UTC(),
+		Data: ProcessingFailedData{
+			Namespace: ic.Namespace,
+			Hash:      ic.ID,
+			Filename:  ic.Filename,
+			Format:    ic.Format,
+			Error:     errMsg,
+		},
+	}
+}
+
+// NewBatchCompletePayload creates a payload for image.batch_complete events
+func NewBatchCompletePayload(namespace, hash, sourceURL string) *Payload {
+	return &Payload{
+		Event:     EventBatchComplete,
+		Timestamp: time.Now().UTC(),
+		Data: BatchCompleteData{
+			Namespace: namespace,
+			Hash:      hash,
+			SourceURL: sourceURL,
+		},
+	}
+}

--- a/logger/webhook/signature.go
+++ b/logger/webhook/signature.go
@@ -1,0 +1,48 @@
+package webhook
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// SignPayload signs a webhook payload using HMAC-SHA256
+// The signature is computed over: timestamp.body
+// This matches the common pattern used by Stripe, GitHub, etc.
+func SignPayload(secret string, timestamp time.Time, body []byte) string {
+	ts := strconv.FormatInt(timestamp.Unix(), 10)
+	message := fmt.Sprintf("%s.%s", ts, string(body))
+
+	h := hmac.New(sha256.New, []byte(secret))
+	h.Write([]byte(message))
+
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// Headers returns the signature headers to include in the webhook request
+type Headers struct {
+	Signature string
+	Timestamp int64
+}
+
+// GenerateHeaders creates the webhook signature headers
+func GenerateHeaders(secret string, body []byte) *Headers {
+	timestamp := time.Now().UTC()
+	signature := SignPayload(secret, timestamp, body)
+
+	return &Headers{
+		Signature: fmt.Sprintf("sha256=%s", signature),
+		Timestamp: timestamp.Unix(),
+	}
+}
+
+// VerifySignature verifies a webhook signature (useful for testing)
+func VerifySignature(secret string, timestamp int64, body []byte, signature string) bool {
+	ts := time.Unix(timestamp, 0)
+	expected := fmt.Sprintf("sha256=%s", SignPayload(secret, ts, body))
+
+	return hmac.Equal([]byte(expected), []byte(signature))
+}

--- a/logger/webhook/webhook.go
+++ b/logger/webhook/webhook.go
@@ -1,0 +1,207 @@
+package webhook
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/image-server/image-server/core"
+	"github.com/image-server/image-server/logger"
+)
+
+const (
+	maxRetries     = 3
+	headerSignature = "X-Webhook-Signature"
+	headerTimestamp = "X-Webhook-Timestamp"
+	userAgent       = "image-server-webhook/1.0"
+)
+
+// Config holds the webhook configuration
+type Config struct {
+	URL     string
+	Secret  string
+	Timeout time.Duration
+	Events  map[EventType]bool
+}
+
+// Logger implements core.Logger for webhook notifications
+type Logger struct {
+	config *Config
+	client *http.Client
+	paths  core.Paths
+}
+
+// Enable registers the webhook logger if a URL is configured
+func Enable(cfg *Config, paths core.Paths) {
+	if cfg == nil || cfg.URL == "" {
+		return
+	}
+
+	if cfg.Timeout == 0 {
+		cfg.Timeout = 10 * time.Second
+	}
+
+	// Default to all events if none specified
+	if cfg.Events == nil || len(cfg.Events) == 0 {
+		cfg.Events = map[EventType]bool{
+			EventImageUploaded:         true,
+			EventImageProcessed:        true,
+			EventImageProcessingFailed: true,
+			EventBatchComplete:         true,
+		}
+	}
+
+	l := &Logger{
+		config: cfg,
+		client: &http.Client{Timeout: cfg.Timeout},
+		paths:  paths,
+	}
+
+	logger.Loggers = append(logger.Loggers, l)
+	log.Printf("Webhook logger enabled: url=%s, events=%v", cfg.URL, cfg.Events)
+}
+
+// send dispatches a webhook payload with retries
+func (l *Logger) send(payload *Payload) {
+	if !l.config.Events[payload.Event] {
+		return
+	}
+
+	go func() {
+		body, err := json.Marshal(payload)
+		if err != nil {
+			log.Printf("webhook: failed to marshal payload: %v", err)
+			return
+		}
+
+		var lastErr error
+		for attempt := 0; attempt < maxRetries; attempt++ {
+			if attempt > 0 {
+				// Exponential backoff: 1s, 4s
+				backoff := time.Duration(attempt*attempt) * time.Second
+				time.Sleep(backoff)
+			}
+
+			if err := l.doSend(body); err != nil {
+				lastErr = err
+				log.Printf("webhook: attempt %d failed: %v", attempt+1, err)
+				continue
+			}
+			return // success
+		}
+
+		log.Printf("webhook: failed after %d attempts: %v", maxRetries, lastErr)
+	}()
+}
+
+// doSend performs a single webhook HTTP request
+func (l *Logger) doSend(body []byte) error {
+	req, err := http.NewRequest(http.MethodPost, l.config.URL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", userAgent)
+
+	// Add signature headers if secret is configured
+	if l.config.Secret != "" {
+		headers := GenerateHeaders(l.config.Secret, body)
+		req.Header.Set(headerSignature, headers.Signature)
+		req.Header.Set(headerTimestamp, strconv.FormatInt(headers.Timestamp, 10))
+	}
+
+	resp, err := l.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+
+	return &WebhookError{StatusCode: resp.StatusCode}
+}
+
+// WebhookError represents a non-2xx response from the webhook endpoint
+type WebhookError struct {
+	StatusCode int
+}
+
+func (e *WebhookError) Error() string {
+	return "webhook returned status " + strconv.Itoa(e.StatusCode)
+}
+
+// --- core.Logger interface implementation ---
+
+// ImagePosted is called when an image upload request is received
+// We don't send a webhook here because we don't have image details yet
+func (l *Logger) ImagePosted() {
+	// No-op: wait for OriginalUploaded which has full image details
+}
+
+// ImagePostingFailed is called when an image upload fails
+func (l *Logger) ImagePostingFailed() {
+	// Could potentially add a generic upload_failed event
+}
+
+// ImageProcessed is called when a single image variant is processed
+func (l *Logger) ImageProcessed(ic *core.ImageConfiguration) {
+	remoteURL := l.paths.RemoteImageURL(ic.Namespace, ic.ID, ic.Filename)
+	payload := NewProcessedPayload(ic, remoteURL)
+	l.send(payload)
+}
+
+// ImageAlreadyProcessed is called when an image variant already exists
+func (l *Logger) ImageAlreadyProcessed(ic *core.ImageConfiguration) {
+	// Don't send webhook for cached/existing images
+}
+
+// ImageProcessedWithErrors is called when image processing fails
+func (l *Logger) ImageProcessedWithErrors(ic *core.ImageConfiguration) {
+	payload := NewProcessingFailedPayload(ic, "processing failed")
+	l.send(payload)
+}
+
+// AllImagesAlreadyProcessed is called when all variants already exist
+func (l *Logger) AllImagesAlreadyProcessed(namespace string, hash string, sourceURL string) {
+	payload := NewBatchCompletePayload(namespace, hash, sourceURL)
+	l.send(payload)
+}
+
+// SourceDownloaded is called when source image is downloaded
+func (l *Logger) SourceDownloaded() {
+	// No-op
+}
+
+// OriginalDownloaded is called when original image is downloaded from remote
+func (l *Logger) OriginalDownloaded(source string, destination string) {
+	// No-op
+}
+
+// OriginalDownloadFailed is called when original download fails
+func (l *Logger) OriginalDownloadFailed(source string) {
+	// No-op
+}
+
+// OriginalDownloadSkipped is called when original download is skipped
+func (l *Logger) OriginalDownloadSkipped(source string) {
+	// No-op
+}
+
+// RequestLatency is called to record request latency
+func (l *Logger) RequestLatency(handler string, since time.Time) {
+	// No-op: latency metrics don't need webhooks
+}
+
+// OriginalUploaded is called when the original image is uploaded to storage
+// This is a new method added to support webhooks with full image details
+func (l *Logger) OriginalUploaded(props *core.ImageProperties, namespace string) {
+	remoteURL := l.paths.RemoteOriginalURL(namespace, props.Hash)
+	payload := NewUploadedPayload(props, namespace, remoteURL)
+	l.send(payload)
+}

--- a/logger/webhook/webhook_test.go
+++ b/logger/webhook/webhook_test.go
@@ -1,0 +1,323 @@
+package webhook
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/image-server/image-server/core"
+)
+
+// mockPaths implements core.Paths for testing
+type mockPaths struct{}
+
+func (m *mockPaths) LocalInfoPath(namespace, hash string) string {
+	return "/local/info/" + namespace + "/" + hash + ".json"
+}
+func (m *mockPaths) RemoteInfoPath(namespace, hash string) string {
+	return "/remote/info/" + namespace + "/" + hash + ".json"
+}
+func (m *mockPaths) TempImagePath(s string) string                        { return "/tmp/" + s }
+func (m *mockPaths) RandomTempPath() string                               { return "/tmp/random" }
+func (m *mockPaths) LocalOriginalPath(namespace, hash string) string      { return "/local/" + namespace + "/" + hash + "/original" }
+func (m *mockPaths) LocalImagePath(namespace, md5, imageName string) string {
+	return "/local/" + namespace + "/" + md5 + "/" + imageName
+}
+func (m *mockPaths) LocalImageDirectory(namespace, md5 string) string {
+	return "/local/" + namespace + "/" + md5
+}
+func (m *mockPaths) RemoteImageDirectory(namespace, md5 string) string {
+	return "/remote/" + namespace + "/" + md5
+}
+func (m *mockPaths) RemoteOriginalPath(namespace, hash string) string {
+	return "/remote/" + namespace + "/" + hash + "/original"
+}
+func (m *mockPaths) RemoteOriginalURL(namespace, hash string) string {
+	return "https://cdn.example.com/" + namespace + "/" + hash + "/original"
+}
+func (m *mockPaths) RemoteImagePath(namespace, md5, imageName string) string {
+	return "/remote/" + namespace + "/" + md5 + "/" + imageName
+}
+func (m *mockPaths) RemoteImageURL(namespace, md5, imageName string) string {
+	return "https://cdn.example.com/" + namespace + "/" + md5 + "/" + imageName
+}
+
+func TestSignature(t *testing.T) {
+	secret := "test-secret"
+	body := []byte(`{"event":"image.uploaded"}`)
+	timestamp := time.Unix(1702135800, 0)
+
+	sig := SignPayload(secret, timestamp, body)
+
+	// Verify the signature is consistent
+	sig2 := SignPayload(secret, timestamp, body)
+	if sig != sig2 {
+		t.Error("Signature should be deterministic")
+	}
+
+	// Verify different secret produces different signature
+	sig3 := SignPayload("different-secret", timestamp, body)
+	if sig == sig3 {
+		t.Error("Different secret should produce different signature")
+	}
+}
+
+func TestVerifySignature(t *testing.T) {
+	secret := "test-secret"
+	body := []byte(`{"event":"image.uploaded"}`)
+
+	headers := GenerateHeaders(secret, body)
+
+	if !VerifySignature(secret, headers.Timestamp, body, headers.Signature) {
+		t.Error("Valid signature should verify")
+	}
+
+	if VerifySignature("wrong-secret", headers.Timestamp, body, headers.Signature) {
+		t.Error("Invalid secret should not verify")
+	}
+
+	if VerifySignature(secret, headers.Timestamp, []byte("tampered"), headers.Signature) {
+		t.Error("Tampered body should not verify")
+	}
+}
+
+func TestWebhookPayloads(t *testing.T) {
+	t.Run("UploadedPayload", func(t *testing.T) {
+		props := &core.ImageProperties{
+			Hash:        "abc123",
+			Width:       1920,
+			Height:      1080,
+			ContentType: "image/jpeg",
+		}
+		payload := NewUploadedPayload(props, "avatars", "https://cdn.example.com/avatars/abc123/original")
+
+		if payload.Event != EventImageUploaded {
+			t.Errorf("Expected event %s, got %s", EventImageUploaded, payload.Event)
+		}
+
+		data := payload.Data.(UploadedData)
+		if data.Namespace != "avatars" {
+			t.Errorf("Expected namespace avatars, got %s", data.Namespace)
+		}
+		if data.Hash != "abc123" {
+			t.Errorf("Expected hash abc123, got %s", data.Hash)
+		}
+		if data.Width != 1920 {
+			t.Errorf("Expected width 1920, got %d", data.Width)
+		}
+	})
+
+	t.Run("ProcessedPayload", func(t *testing.T) {
+		ic := &core.ImageConfiguration{
+			ID:        "abc123",
+			Namespace: "avatars",
+			Filename:  "x300.webp",
+			Format:    "webp",
+			Width:     300,
+			Height:    169,
+			Quality:   75,
+		}
+		payload := NewProcessedPayload(ic, "https://cdn.example.com/avatars/abc123/x300.webp")
+
+		if payload.Event != EventImageProcessed {
+			t.Errorf("Expected event %s, got %s", EventImageProcessed, payload.Event)
+		}
+
+		data := payload.Data.(ProcessedData)
+		if data.Filename != "x300.webp" {
+			t.Errorf("Expected filename x300.webp, got %s", data.Filename)
+		}
+	})
+
+	t.Run("BatchCompletePayload", func(t *testing.T) {
+		payload := NewBatchCompletePayload("avatars", "abc123", "https://source.example.com/image.jpg")
+
+		if payload.Event != EventBatchComplete {
+			t.Errorf("Expected event %s, got %s", EventBatchComplete, payload.Event)
+		}
+
+		data := payload.Data.(BatchCompleteData)
+		if data.SourceURL != "https://source.example.com/image.jpg" {
+			t.Errorf("Expected source URL, got %s", data.SourceURL)
+		}
+	})
+}
+
+func TestWebhookDelivery(t *testing.T) {
+	var mu sync.Mutex
+	var receivedPayloads []Payload
+	var receivedHeaders http.Header
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		receivedHeaders = r.Header.Clone()
+
+		body, _ := io.ReadAll(r.Body)
+		var payload Payload
+		json.Unmarshal(body, &payload)
+		receivedPayloads = append(receivedPayloads, payload)
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	logger := &Logger{
+		config: &Config{
+			URL:     server.URL,
+			Secret:  "test-secret",
+			Timeout: 5 * time.Second,
+			Events: map[EventType]bool{
+				EventImageUploaded:  true,
+				EventImageProcessed: true,
+			},
+		},
+		client: &http.Client{Timeout: 5 * time.Second},
+		paths:  &mockPaths{},
+	}
+
+	// Test OriginalUploaded
+	props := &core.ImageProperties{
+		Hash:        "abc123",
+		Width:       1920,
+		Height:      1080,
+		ContentType: "image/jpeg",
+	}
+	logger.OriginalUploaded(props, "avatars")
+
+	// Wait for async delivery
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	if len(receivedPayloads) != 1 {
+		t.Errorf("Expected 1 payload, got %d", len(receivedPayloads))
+	}
+
+	if receivedHeaders.Get(headerSignature) == "" {
+		t.Error("Expected signature header")
+	}
+	if receivedHeaders.Get(headerTimestamp) == "" {
+		t.Error("Expected timestamp header")
+	}
+	mu.Unlock()
+}
+
+func TestWebhookEventFiltering(t *testing.T) {
+	var mu sync.Mutex
+	requestCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requestCount++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Only enable uploaded events
+	logger := &Logger{
+		config: &Config{
+			URL:     server.URL,
+			Timeout: 5 * time.Second,
+			Events: map[EventType]bool{
+				EventImageUploaded: true,
+				// EventImageProcessed is NOT enabled
+			},
+		},
+		client: &http.Client{Timeout: 5 * time.Second},
+		paths:  &mockPaths{},
+	}
+
+	// This should send a webhook
+	logger.OriginalUploaded(&core.ImageProperties{Hash: "abc123"}, "test")
+
+	// This should NOT send a webhook (event not enabled)
+	logger.ImageProcessed(&core.ImageConfiguration{ID: "abc123", Namespace: "test", Filename: "x300.jpg"})
+
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	if requestCount != 1 {
+		t.Errorf("Expected 1 request (only uploaded), got %d", requestCount)
+	}
+	mu.Unlock()
+}
+
+func TestWebhookRetry(t *testing.T) {
+	var mu sync.Mutex
+	requestCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requestCount++
+		count := requestCount
+		mu.Unlock()
+
+		// Fail first 2 requests, succeed on 3rd
+		if count < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	logger := &Logger{
+		config: &Config{
+			URL:     server.URL,
+			Timeout: 5 * time.Second,
+			Events: map[EventType]bool{
+				EventImageUploaded: true,
+			},
+		},
+		client: &http.Client{Timeout: 5 * time.Second},
+		paths:  &mockPaths{},
+	}
+
+	logger.OriginalUploaded(&core.ImageProperties{Hash: "abc123"}, "test")
+
+	// Wait for retries (1s + 4s backoff + processing time)
+	time.Sleep(6 * time.Second)
+
+	mu.Lock()
+	if requestCount != 3 {
+		t.Errorf("Expected 3 requests (2 failures + 1 success), got %d", requestCount)
+	}
+	mu.Unlock()
+}
+
+func TestWebhookNoSecret(t *testing.T) {
+	var receivedHeaders http.Header
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	logger := &Logger{
+		config: &Config{
+			URL:     server.URL,
+			Secret:  "", // No secret
+			Timeout: 5 * time.Second,
+			Events: map[EventType]bool{
+				EventImageUploaded: true,
+			},
+		},
+		client: &http.Client{Timeout: 5 * time.Second},
+		paths:  &mockPaths{},
+	}
+
+	logger.OriginalUploaded(&core.ImageProperties{Hash: "abc123"}, "test")
+
+	time.Sleep(100 * time.Millisecond)
+
+	if receivedHeaders.Get(headerSignature) != "" {
+		t.Error("Should not have signature header when no secret configured")
+	}
+}

--- a/request/create.go
+++ b/request/create.go
@@ -3,8 +3,10 @@ package request
 import (
 	"log"
 
+	"github.com/image-server/image-server/core"
 	"github.com/image-server/image-server/fetcher"
 	"github.com/image-server/image-server/info"
+	"github.com/image-server/image-server/logger"
 	"github.com/image-server/image-server/uploader"
 )
 
@@ -69,6 +71,15 @@ func (r *Request) UploadOriginal(imageDetails *info.ImageProperties) error {
 	if err != nil {
 		return err
 	}
+
+	// Notify loggers (including webhooks) that original was uploaded
+	logger.OriginalUploaded(&core.ImageProperties{
+		Hash:        imageDetails.Hash,
+		Height:      imageDetails.Height,
+		Width:       imageDetails.Width,
+		ContentType: imageDetails.ContentType,
+	}, r.Namespace)
+
 	return nil
 }
 


### PR DESCRIPTION
Implements webhook notifications to external systems when images are uploaded or processed. Useful for triggering downstream workflows like OCR, ML pipelines, or cache invalidation.

Features:
- Four event types: uploaded, processed, failed, batch_complete
- HMAC-SHA256 signed payloads for security
- Configurable event filtering
- Async delivery with retry (3 attempts, exponential backoff)
- Non-blocking - webhook failures don't affect image processing

New CLI flags:
- --webhook-url: Endpoint URL (enables webhooks when set)
- --webhook-secret: HMAC signing secret
- --webhook-timeout: HTTP timeout in seconds (default 10)
- --webhook-events: Comma-separated list of events to send